### PR TITLE
Fix initalization flow by actually setting the context properly

### DIFF
--- a/src/providers/FrameContextProvider.tsx
+++ b/src/providers/FrameContextProvider.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { Loading } from '@/components/ui/loading';
 
-const FAKE_FRAME_CONTEXT =
+const FAKE_FRAME_CONTEXT: FrameContext | undefined =
   process.env.NODE_ENV === 'development'
     ? {
         user: {
@@ -15,6 +15,7 @@ const FAKE_FRAME_CONTEXT =
           clientFid: 9152,
           added: false,
         },
+        // @ts-ignore-next-line
         fakePayload: true,
       }
     : undefined;
@@ -38,10 +39,11 @@ function FrameContextProvider({ children }: React.PropsWithChildren) {
   const checkFrameContext = React.useCallback(async () => {
     const ctx: FrameContext = await sdk.context;
 
-    // eslint-disable-next-line no-console
-    console.warn({ ctx });
-
-    if (typeof frameContext !== 'undefined' && frameContext !== null) {
+    if (
+      typeof ctx !== 'undefined' &&
+      ctx !== null &&
+      typeof frameContext === 'undefined'
+    ) {
       setFrameContext(ctx);
     } else {
       setNoFrameContextFound(true);
@@ -53,9 +55,6 @@ function FrameContextProvider({ children }: React.PropsWithChildren) {
       checkFrameContext();
     }
   }, [checkFrameContext, frameContext]);
-
-  // eslint-disable-next-line no-console
-  console.warn({ noFrameContextFound, frameContext });
 
   if (noFrameContextFound) {
     return <Loading />;

--- a/src/providers/FrameSplashProvider.tsx
+++ b/src/providers/FrameSplashProvider.tsx
@@ -12,8 +12,6 @@ const FrameSplashProviderContext =
 
 function FrameSplashProvider({ children }: React.PropsWithChildren) {
   const dismiss = React.useCallback(async () => {
-    // eslint-disable-next-line no-console
-    console.warn('dismiss called');
     sdk.actions.ready({
       disableNativeGestures: false,
     });


### PR DESCRIPTION
We were checking whether existing local state being defined instead
of what we get from the SDK.

Relates WARP-4025
