### PR TITLE
Drop the min score visibility from 1K to 500

### DIFF
--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -1,4 +1,4 @@
-const MIN_SCORE_FORMATTER_TARGET = 1e3;
+const MIN_SCORE_FORMATTER_TARGET = 1e3 / 2;
 
 function formatScore({ score }: { score: number }) {
   return score < MIN_SCORE_FORMATTER_TARGET


### PR DESCRIPTION
Should be more informative for most of the network moving forward.

Requires Warpcast servers to adjust results returned back.
